### PR TITLE
Suppression de (e)

### DIFF
--- a/language/fr.json
+++ b/language/fr.json
@@ -1,5 +1,5 @@
 {
-    "beforeQuit": "Êtes-vous sûr(e) de vouloir quitter ?",
+    "beforeQuit": "Êtes-vous sûr de vouloir quitter ?",
     "loading": "Patientez...",
     "loadingVideo": "Chargement de la vidéo, merci de patienter...",
     "searchLoading": "Recherche...",


### PR DESCRIPTION
L'utilisation de "(e)" est déconseillée (voir : http://www.academie-francaise.fr/actualites/feminisation-des-noms-de-metiers-fonctions-grades-et-titres)
