### PR TITLE
Fixes on cache in reason of multiple subtitles

### DIFF
--- a/js/frontend/providers/cache.js
+++ b/js/frontend/providers/cache.js
@@ -63,7 +63,21 @@ App.Cache = {
         db.transaction(function (tx) {
             tx.executeSql('CREATE TABLE IF NOT EXISTS ' + provider + ' (key TEXT, data TEXT)');
 
-            tx.executeSql('INSERT INTO ' + provider + ' VALUES (?, ?)', [key, data]);
+            //Implementation to check if exist registration in db and update instead of insert
+            //Does a SELECT on Provider
+            tx.executeSql('SELECT data FROM ' + provider + ' WHERE key = ?', [key], function (tx, results) {
+                try {
+                    if (results.rows.length) {
+                        tx.executeSql('UPDATE ' + provider + ' SET data = ? WHERE key = ?', [data, key]);
+                    } else {
+                        tx.executeSql('INSERT INTO ' + provider + ' VALUES (?, ?)', [key, data]);
+                    }
+                } catch (e) {
+                    if (isDebug) {
+                        throw e;
+                    }
+                }
+            });
         });
     }
 };

--- a/js/frontend/providers/cache.js
+++ b/js/frontend/providers/cache.js
@@ -72,11 +72,7 @@ App.Cache = {
                     } else {
                         tx.executeSql('INSERT INTO ' + provider + ' VALUES (?, ?)', [key, data]);
                     }
-                } catch (e) {
-                    if (isDebug) {
-                        throw e;
-                    }
-                }
+                } 
             });
         });
     }

--- a/js/frontend/providers/cache.js
+++ b/js/frontend/providers/cache.js
@@ -66,13 +66,11 @@ App.Cache = {
             //Implementation to check if exist registration in db and update instead of insert
             //Does a SELECT on Provider
             tx.executeSql('SELECT data FROM ' + provider + ' WHERE key = ?', [key], function (tx, results) {
-                try {
-                    if (results.rows.length) {
-                        tx.executeSql('UPDATE ' + provider + ' SET data = ? WHERE key = ?', [data, key]);
-                    } else {
-                        tx.executeSql('INSERT INTO ' + provider + ' VALUES (?, ?)', [key, data]);
-                    }
-                } 
+                if (results.rows.length) {
+                    tx.executeSql('UPDATE ' + provider + ' SET data = ? WHERE key = ?', [data, key]);
+                } else {
+                    tx.executeSql('INSERT INTO ' + provider + ' VALUES (?, ?)', [key, data]);
+                }
             });
         });
     }


### PR DESCRIPTION
I made a change in the cache, because i saw having several occurrences of the same film with various languages in subtitles, for example: 
{"Movie 1", "English: ..."} 
{"Movie 1", "English: ... Spanish: ..."} 
.
{"Movie 1", "English: ... Spanish ..., N '}

Now the cache verify if have an occurrence before insert in DB, if exists it makes a update, if not exists it makes a insert.

Enjoy
