### PR TITLE
Added start script to help debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "grunt-contrib-sass": "~0.7.1",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-compass": "~0.7.1"
+  },
+  "scripts": {
+    "start": "node start.js"
   }
 }

--- a/start.js
+++ b/start.js
@@ -1,0 +1,37 @@
+var path = require('path');
+var child_process = require('child_process');
+
+var exeNames = {
+    windows: 'nw.exe',
+    linux: 'nw',
+    mac: ''
+};
+var osName = getOperatingSystem();
+if(osName == 'windows' || osName == 'linux') {
+    var exePath = path.join(__dirname, 'node-webkit', osName, exeNames[osName]);
+    var child = child_process.spawn(exePath, [__dirname], {
+        cwd: __dirname,
+        detached: true,
+        stdio: 'ignore'
+    });
+    child.unref();
+}
+// Mac not supported yet. I don't know how to start a .app directory.
+// If someone else does, feel free to add it
+
+
+function getOperatingSystem() {
+    var os = require('os');
+    var platform = os.platform();
+
+    if( platform == 'win32' || platform == 'win64' ) {
+        return 'windows';
+    }
+    if( platform == 'darwin' ) {
+        return 'mac';
+    }
+    if( platform == 'linux' ) {
+        return 'linux';
+    }
+    return null;
+}

--- a/start.js
+++ b/start.js
@@ -9,7 +9,7 @@ var exeNames = {
 var osName = getOperatingSystem();
 if(osName == 'windows' || osName == 'linux') {
     var exePath = path.join(__dirname, 'node-webkit', osName, exeNames[osName]);
-    var child = child_process.spawn(exePath, [__dirname], {
+    var child = child_process.spawn(exePath, [__dirname, '--debug'], {
         cwd: __dirname,
         detached: true,
         stdio: 'ignore'


### PR DESCRIPTION
It doesn't support Mac yet (I don't know how you start a mac app), but someone else should add support if they can. I don't know if there was another method everyone was using to start it, but this seemed handy.
