### PR TITLE
Changing onMouseDown to onMouseUp to play/pause a movie

### DIFF
--- a/js/vendor/video-js/video.dev.js
+++ b/js/vendor/video-js/video.dev.js
@@ -4123,7 +4123,7 @@ vjs.PlayToggle.prototype.buildCSSClass = function(){
 };
 
 // OnClick - Toggle between play and pause
-vjs.PlayToggle.prototype.onClick = function(){
+vjs.PlayToggle.prototype.onMouseUp = function(){
   if (this.player_.paused()) {
     this.player_.play();
   } else {
@@ -5013,7 +5013,7 @@ vjs.MediaTechController.prototype.removeControlsListeners = function(){
 /**
  * Handle a click on the media element. By default will play/pause the media.
  */
-vjs.MediaTechController.prototype.onClick = function(event){
+vjs.MediaTechController.prototype.onMouseUp = function(event){
   // We're using mousedown to detect clicks thanks to Flash, but mousedown
   // will also be triggered with right-clicks, so we need to prevent that
   if (event.button !== 0) return;


### PR DESCRIPTION
Actually, when you click (`onMouseDown`) on player screen, you play/pause the movie. Only changing to `onMouseUp` to improve UX.
