### PR TITLE
Add the repository field to get rid of the annoying npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "Popcorn-Time",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/popcorn-time/popcorn-app.git"
+  },
   "main": "app://host/index.html",
   "version": "0.2.0",
   "window": {


### PR DESCRIPTION
Not sure if there's a reason for not adding this already but i'm really annoyed by the warning npm emits when the [repository](https://www.npmjs.org/doc/json.html#repository) field isn't available.

```
npm WARN package.json Popcorn-Time@0.2.0 No repository field
```
