### PR TITLE
Toggle platforms to build with grunt cli option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,10 +21,10 @@ module.exports = function(grunt) {
         version: '0.9.2',
         build_dir: './build', // Where the build version of my node-webkit app is saved
         mac_icns: './images/popcorntime.icns', // Path to the Mac icon file
-        mac: buildPlatforms.mac, // We want to build it for mac
-        win: buildPlatforms.win, // We want to build it for win
+        mac: buildPlatforms.mac,
+        win: buildPlatforms.win,
         linux32: false, // We don't need linux32
-        linux64: buildPlatforms.linux64 // We don't need linux64
+        linux64: buildPlatforms.linux64
       },
       src: ['./css/**', './fonts/**', './images/**', './js/**', './language/**', './node_modules/**', '!./node_modules/grunt*/**', './rc/**', './Config.rb', './index.html', './package.json', './README.md' ] // Your node-webkit app './**/*'
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
-  module.exports = function(grunt) {
+module.exports = function(grunt) {
+  var buildPlatforms = parseBuildPlatforms(grunt.option('platforms'));
 
   grunt.initConfig({
     compass: {
@@ -20,10 +21,10 @@
         version: '0.9.2',
         build_dir: './build', // Where the build version of my node-webkit app is saved
         mac_icns: './images/popcorntime.icns', // Path to the Mac icon file
-        mac: true, // We want to build it for mac
-        win: true, // We want to build it for win
+        mac: buildPlatforms.mac, // We want to build it for mac
+        win: buildPlatforms.win, // We want to build it for win
         linux32: false, // We don't need linux32
-        linux64: true // We don't need linux64
+        linux64: buildPlatforms.linux64 // We don't need linux64
       },
       src: ['./css/**', './fonts/**', './images/**', './js/**', './language/**', './node_modules/**', '!./node_modules/grunt*/**', './rc/**', './Config.rb', './index.html', './package.json', './README.md' ] // Your node-webkit app './**/*'
     },
@@ -61,3 +62,17 @@
 
 
 };
+
+var parseBuildPlatforms = function(argumentPlatform) {
+  // this will make it build no platform when the platform option is specified
+  // without a value which makes argumentPlatform into a boolean
+  var inputPlatforms = argumentPlatform || process.platform;
+
+  var buildPlatforms = {
+    mac: /darwin|mac/.test(inputPlatforms),
+    win: /win/.test(inputPlatforms),
+    linux64: /linux/.test(inputPlatforms)
+  };
+
+  return buildPlatforms;
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
         mac_icns: './images/popcorntime.icns', // Path to the Mac icon file
         mac: buildPlatforms.mac,
         win: buildPlatforms.win,
-        linux32: false, // We don't need linux32
+        linux32: buildPlatforms.linux32,
         linux64: buildPlatforms.linux64
       },
       src: ['./css/**', './fonts/**', './images/**', './js/**', './language/**', './node_modules/**', '!./node_modules/grunt*/**', './rc/**', './Config.rb', './index.html', './package.json', './README.md' ] // Your node-webkit app './**/*'
@@ -66,12 +66,17 @@ module.exports = function(grunt) {
 var parseBuildPlatforms = function(argumentPlatform) {
   // this will make it build no platform when the platform option is specified
   // without a value which makes argumentPlatform into a boolean
-  var inputPlatforms = argumentPlatform || process.platform;
+  var inputPlatforms = argumentPlatform || process.platform + ";" + process.arch;
+
+  // Do some scrubbing to make it easier to match in the regexes bellow
+  inputPlatforms = inputPlatforms.replace("darwin", "mac");
+  inputPlatforms = inputPlatforms.replace(/;ia|;x|;arm/, "");
 
   var buildPlatforms = {
-    mac: /darwin|mac/.test(inputPlatforms),
+    mac: /mac/.test(inputPlatforms),
     win: /win/.test(inputPlatforms),
-    linux64: /linux/.test(inputPlatforms)
+    linux32: /linux32/.test(inputPlatforms),
+    linux64: /linux64/.test(inputPlatforms)
   };
 
   return buildPlatforms;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,11 +72,13 @@ var parseBuildPlatforms = function(argumentPlatform) {
   inputPlatforms = inputPlatforms.replace("darwin", "mac");
   inputPlatforms = inputPlatforms.replace(/;ia|;x|;arm/, "");
 
+  var buildAll = /^all$/.test(inputPlatforms);
+
   var buildPlatforms = {
-    mac: /mac/.test(inputPlatforms),
-    win: /win/.test(inputPlatforms),
-    linux32: /linux32/.test(inputPlatforms),
-    linux64: /linux64/.test(inputPlatforms)
+    mac: /mac/.test(inputPlatforms) || buildAll,
+    win: /win/.test(inputPlatforms) || buildAll,
+    linux32: /linux32/.test(inputPlatforms) || buildAll,
+    linux64: /linux64/.test(inputPlatforms) || buildAll
   };
 
   return buildPlatforms;

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ By default it will build for your current platform however you can control that
 by specifying a comma separated list of platforms in the `platforms` option to
 grunt:
 
-    $ grunt nodewkbuild --platforms=linux,mac,win
+    $ grunt nodewkbuild --platforms=linux32,linux64,mac,win
 
 ## Any problem?
 

--- a/README.md
+++ b/README.md
@@ -31,21 +31,6 @@ You will need nodejs and grunt:
 
     $ npm install -g grunt-cli
 
-### Select your OS
-
-Enable your Operating System in `Gruntfile.js` and disable all the others:
-
-    …
-    nodewebkit: {
-      options: {
-        …
-        mac: false,
-        win: false,
-        linux32: false,
-        linux64: true
-      },
-    …
-
 ### Build
 
 Install the node modules:
@@ -56,6 +41,11 @@ Built with:
 
     $ grunt nodewkbuild
 
+By default it will build for your current platform however you can control that
+by specifying a comma separated list of platforms in the `platforms` option to
+grunt:
+
+    $ grunt nodewkbuild --platforms=linux,mac,win
 
 ## Any problem?
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Install the node modules:
 
     $ npm install
 
-Built with:
+Build with:
 
     $ grunt nodewkbuild
 
@@ -46,6 +46,10 @@ by specifying a comma separated list of platforms in the `platforms` option to
 grunt:
 
     $ grunt nodewkbuild --platforms=linux32,linux64,mac,win
+
+You can also build for all platforms with:
+
+    $ grunt nodewkbuild --platforms=all
 
 ## Any problem?
 


### PR DESCRIPTION
Toggle platforms to build with grunt cli option instead of manual toggle in Gruntfile.js. This allows you to invoke grunt like this:

```
$ grunt nodewkbuild
```

And it will build only for the current platform. Or like this:

```
$ grunt nodewkbuild --platforms=win,linux,mac
```

And it will build for the specified platforms in the comma separated list.

This probably shouldn't be merged without fixing the regex for windows. It currently evaluates to true when process.platform is darwin (on os x). I can fix if you want this but just couldn't think of some nice solution for now...
