### PR TITLE
Fixed bug where sometimes backdropCache's onload event would trigger incorectly

### DIFF
--- a/js/frontend/views/sidebar.js
+++ b/js/frontend/views/sidebar.js
@@ -141,15 +141,16 @@ App.View.Sidebar = Backbone.View.extend({
 
       $('.movie.active').removeClass('active');
       this.$el.addClass('hidden');
+      this.backdropCache.src = null;
     },
 
     show: function () {
         $('body').removeClass().addClass('sidebar-open');
         this.$el.removeClass('hidden');
 
-        var backdropCache = new Image();
-        backdropCache.src = this.model.get('backdrop');
-        backdropCache.onload = function () {
+        this.backdropCache = new Image();
+        this.backdropCache.src = this.model.get('backdrop');
+        this.backdropCache.onload = function () {
             $(".backdrop-image").addClass("loaded")
         };
 


### PR DESCRIPTION
... causing the backdrop-image to load without any animation if you closed a movie's info panel before the image finished loading and quickly opened another one.
