### PR TITLE
Fixed an Uncaught TypeError on a search

### DIFF
--- a/js/frontend/controllers/search.js
+++ b/js/frontend/controllers/search.js
@@ -1,5 +1,5 @@
 App.Controller.Search = function (searchTerm, page) {
-    // Check if page doesn't exists
+    // Check if page doesn't exist
     if (App.Page.Search === null || typeof App.Page.Search === 'undefined') {
         // Create page
         App.Page.Search = new App.View.Page({

--- a/js/frontend/controllers/search.js
+++ b/js/frontend/controllers/search.js
@@ -1,6 +1,6 @@
 App.Controller.Search = function (searchTerm, page) {
     // Check if page doesn't exist
-    if (App.Page.Search === null || typeof App.Page.Search === 'undefined') {
+    if (!App.Page.Search) {
         // Create page
         App.Page.Search = new App.View.Page({
             id: 'search-list'

--- a/js/frontend/controllers/search.js
+++ b/js/frontend/controllers/search.js
@@ -1,6 +1,6 @@
 App.Controller.Search = function (searchTerm, page) {
-    // Check if page exists
-    if (App.Page.Search) {
+    // Check if page doesn't exists
+    if (App.Page.Search === null || typeof App.Page.Search === 'undefined') {
         // Create page
         App.Page.Search = new App.View.Page({
             id: 'search-list'


### PR DESCRIPTION
An `Uncaught TypeError: Cannot call method 'show' of undefined` was being thrown by `App.Page.Search.show()`.  I believe it should be checking if `App.Page.Search` doesn't exist before trying to create it.
