### PR TITLE
Fix accentuation for Spanish

### DIFF
--- a/language/es.json
+++ b/language/es.json
@@ -16,7 +16,7 @@
   "startingDownload": "Iniciando la descarga...",
   "downloading": "Descargando...",
   "UpgradeVersion": "Actualizar Popcorn Time",
-  "UpgradeVersionDescription": "Popcorn Time %s acaba de salir. ¡Descargala ahora!",
+  "UpgradeVersionDescription": "Popcorn Time %s acaba de salir. ¡Descárgala ahora!",
   "legalDisclaimer": "Popcorn Time descarga y comparte películas utilizando torrents, algo que puede ser ilegal en tu país.",
   "legalDisclaimerResponsible": "No nos hacemos responsables de los problemas que esto te pueda causar, asegúrate de comprender nuestros Términos y Condiciones antes de usar Popcorn Time.",
   "legalDisclaimerAccept": "Comprendo, quiero usar Popcorn Time",


### PR DESCRIPTION
"Descárgala" should be accentuated since every proparoxytone word is accentuated. You can also Google "Descargala" without accent and see that almost every result is accentuated.

P.D. TIL the word Proparoxytone :)
