### PR TITLE
Remove seek handle

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1964,6 +1964,9 @@ sidebar .play .movie-detail .side-content a.play-button:hover {
 #video_player.video-js .vjs-menu-item {
   color: #000;
 }
+#video_player.video-js .vjs-seek-handle {
+  display: none;
+}
 
 body.watching #header, body.watching #notification, body.watching #catalog-select, body.watching .container {
   visibility: hidden;

--- a/sass/_player.scss
+++ b/sass/_player.scss
@@ -102,6 +102,7 @@
   .vjs-big-play-button { font-size: 1em; }
   .vjs-control-bar { font-size: 10px; }
   .vjs-menu-item { color: #000; }
+  .vjs-seek-handle { display: none; }
 }
 
 


### PR DESCRIPTION
The circle that acts as seek handle is annoying and removing it allows you to be more precise when seeking.
![captura de pantalla 2014-03-13 a la s 12 23 42](https://f.cloud.github.com/assets/1706695/2408779/fcc4f634-aaa1-11e3-8895-d4c2d3cb2aea.png)
