### PR TITLE
Fixes 2 bugs with fullscreen:

### DIFF
--- a/js/frontend/ui.js
+++ b/js/frontend/ui.js
@@ -37,15 +37,14 @@ jQuery(function ($) {
 
   // Maximize, minimize
   $('.btn-os.max').on('click', function () {
-    if(win.isFullscreen){
+    if(win.isFullscreen) {
       win.toggleFullscreen();
-    }else{
-      if (screen.availHeight <= win.height) {
-        win.unmaximize();
-      }
-      else {
-          win.maximize();
-      }
+      win.unmaximize();
+      $('.btn-os.fullscreen').toggleClass('active');
+    } else if (screen.availHeight <= win.height) {
+      win.unmaximize();
+    } else {
+      win.maximize();
     }
   });
 


### PR DESCRIPTION
1. Properly toggle active class on $('.btn-os.fullscreen') when exiting
   fullscreen from the maximize button. Before this commit the button class
   won't be toggled and the button would show incorrect icons.
2. Fixes a bug where it got weird and unintuitive if the user wanted to
   incorrectly unmaximize the window while being in fullscreen -- with the
   window already unmaximized (but in fullscreen). Now, if the user
   clicks the maximize button while being in fullscreen, it not only exits
   fullscreen but also unmaximizes it.

PS: Mi ingles apesta.. espero se entienda!
