### PR TITLE
Don't toggle play/pause when cliking the player screen

### DIFF
--- a/js/vendor/videojsplugins.js
+++ b/js/vendor/videojsplugins.js
@@ -248,3 +248,17 @@ vjs.TextTrack.prototype.load = function(){
   }
 
 };
+
+function(vjs) {
+  var superAddControlsListeners = vjs.MediaTechController.prototype.addControlsListeners;
+
+  vjs.MediaTechController.prototype.addControlsListeners = function() {
+    superAddControlsListeners.call(this);
+    // Don't toggle play/pause with a click on the movie player. Often you want
+    // to drag the screen and the play/pause stuff is pretty annoying.
+    //
+    // Disabling the event is speedier than just overriding the onClick method
+    // with a noop.
+    this.off('mousedown');
+  }
+}(videojs);


### PR DESCRIPTION
At least on OSX, its pretty common for players to allow you to drag the window and it gets pretty annoying to pause the playback while doing so. The click also gets in the way of the double click for quick fullscreen.

The solution is kinda hacky, as it monkey patches videojs.
