### PR TITLE
Update pt-br.json

### DIFF
--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -10,7 +10,7 @@
   "search": "Procurar",
   "movies": "Filmes",
 
-  "subtitledIn": "Legendas em",
+  "subtitledIn": "Legendado em",
   "quality": "Qualidade",
   "watchItNow": "Assistir agora",
   "durationUnit": "min",
@@ -61,5 +61,10 @@
   "romanian": "Romeno",
   "turkish": "Turco",
   "dutch": "Holandês",
-  "italian": "Italiano"
+  "italian": "Italiano",
+  "danish": "Dinamarquês",
+  "arabic": "Árabe",
+  "korean": "Coreano",
+  "hungarian": "Húngaro",
+  "bulgarian": "Búlgaro"
 }


### PR DESCRIPTION
"Legendas em" isn't completely wrong, but in case the movie only have one subtitle, it is wrong, as the literal translation would mean "subtitles in".
Added Danish, Arabic, Korean, Hungarian and Bulgarian localisations.
