### PR TITLE
Change tmp folder name

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,7 @@ var
     url = require('url'),
 
     // TMP Folder
-    tmpFolder = path.join(os.tmpDir(), 'Popcorn-Time'),
+    tmpFolder = path.join(os.tmpDir(), 'Popcorn-Time-tmp'),
 
     // i18n module (translations)
     i18n = require("i18n");


### PR DESCRIPTION
Avoid collision with binary name.

I was trying popcorn time, and since I was really trying it, I naturally downloaded it in `/tmp`, and run it from there. Too bad the binary is named exactly the same as the temporary folder. I think a fatal error should also be added if the file exists but is not a directory, like it was the case for me, but I'm not really good at js so I don't know how to do that the right way.
